### PR TITLE
fix: モバイル対応 - iOS Safari ズーム防止・タッチターゲット拡大・デザイン統一

### DIFF
--- a/app/javascript/controllers/burden_selector_controller.js
+++ b/app/javascript/controllers/burden_selector_controller.js
@@ -60,11 +60,12 @@ export default class extends Controller {
 
   _activateBtn(btn) {
     btn.classList.add("border-blue-500", "bg-blue-50", "text-blue-700")
-    btn.classList.remove("border-gray-300", "text-gray-600")
+    btn.classList.remove("border-gray-200", "bg-gray-50", "text-gray-500", "border-gray-300", "text-gray-600")
   }
 
   _deactivateBtn(btn) {
     btn.classList.remove("border-blue-500", "bg-blue-50", "text-blue-700")
-    btn.classList.add("border-gray-300", "text-gray-600")
+    btn.classList.add("border-gray-200", "text-gray-500")
+    btn.classList.remove("border-gray-300", "text-gray-600", "bg-gray-50")
   }
 }

--- a/app/views/cards/_card.html.erb
+++ b/app/views/cards/_card.html.erb
@@ -2,7 +2,7 @@
      class="bg-white rounded-xl border border-gray-200 px-4 py-3 flex items-center justify-between">
   <p class="font-medium text-sm">💳 <%= card.name %></p>
   <div class="flex gap-3">
-    <%= link_to "編集", edit_card_path(card), class: "text-blue-500 text-sm" %>
+    <%= link_to "編集", edit_card_path(card), class: "text-blue-500 text-sm py-2 px-1" %>
     <%= button_to "削除",
           card_path(card),
           method: :delete,
@@ -12,7 +12,7 @@
             data-action="confirm-modal#open"
             data-confirm-modal-message-param="「<%= card.name %>」を削除しますか？"
             data-confirm-modal-form-param="delete_card_<%= card.id %>"
-            class="text-red-500 text-sm">
+            class="text-red-500 text-sm py-2 px-1">
       削除
     </button>
   </div>

--- a/app/views/cards/_form.html.erb
+++ b/app/views/cards/_form.html.erb
@@ -2,7 +2,7 @@
   <div>
     <label class="block text-sm font-medium text-gray-700 mb-1">カード名</label>
     <%= f.text_field :name,
-          class: "w-full border border-gray-300 rounded-xl px-4 py-2.5 text-base",
+          class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
           placeholder: "楽天カード" %>
     <% if card.errors[:name].any? %>
       <p class="text-red-500 text-sm mt-1"><%= card.errors[:name].first %></p>
@@ -13,8 +13,8 @@
     <label class="block text-sm font-medium text-gray-700 mb-2">持ち主</label>
     <div class="flex gap-3">
       <% [["A", @setting.member_a], ["B", @setting.member_b]].each do |value, label| %>
-        <label class="flex-1 flex items-center justify-center gap-2 border rounded-xl py-2.5 cursor-pointer
-                       border-gray-300 text-gray-700 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-700">
+        <label class="flex-1 flex items-center justify-center gap-2 border-2 rounded-xl py-2.5 cursor-pointer
+                       border-gray-200 text-gray-500 has-[:checked]:border-blue-500 has-[:checked]:bg-blue-50 has-[:checked]:text-blue-700">
           <%= f.radio_button :owner, value, class: "sr-only" %>
           <%= label %>
         </label>
@@ -26,5 +26,5 @@
   </div>
 
   <%= f.submit card.new_record? ? "追加する" : "保存する",
-        class: "w-full bg-blue-500 text-white py-3 rounded-xl text-base font-medium mt-2" %>
+        class: "w-full bg-blue-500 text-white py-3.5 rounded-xl text-base font-semibold mt-2" %>
 <% end %>

--- a/app/views/cards/index.html.erb
+++ b/app/views/cards/index.html.erb
@@ -11,7 +11,7 @@
       <% if cards.empty? %>
         <p class="text-gray-400 text-sm py-3">登録なし</p>
       <% else %>
-        <div class="space-y-2">
+        <div class="space-y-3">
           <% cards.each do |card| %>
             <%= render "card", card: card %>
           <% end %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -5,7 +5,7 @@
     <div>
       <label class="block text-sm font-medium text-gray-700 mb-1">メンバーA の名前</label>
       <%= f.text_field :member_a,
-            class: "w-full border border-gray-300 rounded-xl px-4 py-2.5 text-base",
+            class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
             placeholder: "たろう" %>
       <% if @setting.errors[:member_a].any? %>
         <p class="text-red-500 text-sm mt-1"><%= @setting.errors[:member_a].first %></p>
@@ -15,7 +15,7 @@
     <div>
       <label class="block text-sm font-medium text-gray-700 mb-1">メンバーB の名前</label>
       <%= f.text_field :member_b,
-            class: "w-full border border-gray-300 rounded-xl px-4 py-2.5 text-base",
+            class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
             placeholder: "はなこ" %>
       <% if @setting.errors[:member_b].any? %>
         <p class="text-red-500 text-sm mt-1"><%= @setting.errors[:member_b].first %></p>
@@ -23,6 +23,6 @@
     </div>
 
     <%= f.submit "保存する",
-          class: "w-full bg-blue-500 text-white py-3 rounded-xl text-base font-medium mt-2" %>
+          class: "w-full bg-blue-500 text-white py-3.5 rounded-xl text-base font-semibold mt-2" %>
   <% end %>
 </div>

--- a/app/views/sheet_items/_edit_form.html.erb
+++ b/app/views/sheet_items/_edit_form.html.erb
@@ -20,7 +20,7 @@
         <span class="text-sm text-gray-500 shrink-0">カード:</span>
         <%= f.collection_select :card_id, Card.order(:owner, :name), :id, :name,
               { include_blank: "現金" },
-              class: "flex-1 border border-gray-300 rounded-lg px-2 py-1.5 text-sm" %>
+              class: "flex-1 border border-gray-300 rounded-lg px-2 py-2.5" %>
       </div>
 
       <%# 分担モード %>
@@ -28,13 +28,13 @@
         <button type="button"
                 data-action="burden-selector#setSplit"
                 data-burden-selector-target="splitBtn"
-                class="flex-1 py-1.5 rounded-lg border text-sm font-medium border-gray-300 text-gray-600">
+                class="flex-1 py-2.5 rounded-xl border-2 text-sm font-semibold border-gray-200 text-gray-500">
           割り勘
         </button>
         <button type="button"
                 data-action="burden-selector#setCustom"
                 data-burden-selector-target="customBtn"
-                class="flex-1 py-1.5 rounded-lg border text-sm font-medium border-blue-500 bg-blue-50 text-blue-700">
+                class="flex-1 py-2.5 rounded-xl border-2 text-sm font-semibold border-blue-500 bg-blue-50 text-blue-700">
           固定額
         </button>
       </div>

--- a/app/views/sheet_items/_form.html.erb
+++ b/app/views/sheet_items/_form.html.erb
@@ -2,55 +2,58 @@
 <%= form_with model: [sheet, sheet_item],
               url: sheet_sheet_items_path(sheet.year_month),
               id: "new_sheet_item_form",
-              class: "bg-white rounded-xl border border-gray-200 p-4 space-y-3" do |f| %>
+              class: "bg-white rounded-2xl border border-gray-200 p-5 space-y-4" do |f| %>
   <div data-controller="burden-selector"
        data-burden-selector-amount-value="<%= sheet_item.amount.to_i %>">
-    <div class="flex gap-2">
+    <div class="flex gap-3">
       <%= f.text_field :name,
-            class: "flex-1 border border-gray-300 rounded-xl px-3 py-2 text-base",
+            class: "flex-1 border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
             placeholder: "費目名" %>
       <%= f.number_field :amount,
             data: { action: "input->burden-selector#updateAmount" },
-            class: "w-28 border border-gray-300 rounded-xl px-3 py-2 text-base",
+            class: "w-28 border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
             min: 0, placeholder: "金額" %>
     </div>
 
-    <div class="flex gap-2 items-center">
-      <span class="text-sm text-gray-500 shrink-0">カード:</span>
+    <div class="space-y-1">
+      <label class="text-xs font-medium text-gray-400">カード</label>
       <%= f.collection_select :card_id, Card.order(:owner, :name), :id, :name,
             { include_blank: "現金" },
-            class: "flex-1 border border-gray-300 rounded-lg px-2 py-1.5 text-sm" %>
+            class: "w-full border border-gray-200 rounded-xl px-4 py-3 bg-gray-50" %>
     </div>
 
     <%# 分担モード %>
-    <div class="flex gap-2">
-      <button type="button"
-              data-action="burden-selector#setSplit"
-              data-burden-selector-target="splitBtn"
-              class="flex-1 py-1.5 rounded-lg border text-sm font-medium border-blue-500 bg-blue-50 text-blue-700">
-        割り勘
-      </button>
-      <button type="button"
-              data-action="burden-selector#setCustom"
-              data-burden-selector-target="customBtn"
-              class="flex-1 py-1.5 rounded-lg border text-sm font-medium border-gray-300 text-gray-600">
-        固定額
-      </button>
+    <div class="space-y-1.5">
+      <label class="text-xs font-medium text-gray-400">分担</label>
+      <div class="flex gap-2">
+        <button type="button"
+                data-action="burden-selector#setSplit"
+                data-burden-selector-target="splitBtn"
+                class="flex-1 py-2.5 rounded-xl border-2 text-sm font-semibold border-blue-500 bg-blue-50 text-blue-700">
+          割り勘
+        </button>
+        <button type="button"
+                data-action="burden-selector#setCustom"
+                data-burden-selector-target="customBtn"
+                class="flex-1 py-2.5 rounded-xl border-2 text-sm font-semibold border-gray-200 text-gray-500">
+          固定額
+        </button>
+      </div>
     </div>
 
-    <div data-burden-selector-target="customFields" class="hidden gap-2 mt-2">
+    <div data-burden-selector-target="customFields" class="hidden gap-3 mt-0">
       <div class="flex-1">
         <label class="text-xs text-gray-500"><%= @setting.member_a %>負担</label>
         <%= f.number_field :burden_a,
               data: { "burden-selector-target": "burdenA" },
-              class: "w-full border border-gray-300 rounded-xl px-3 py-2 text-base mt-0.5",
+              class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50 mt-1",
               min: 0 %>
       </div>
       <div class="flex-1">
         <label class="text-xs text-gray-500"><%= @setting.member_b %>負担</label>
         <%= f.number_field :burden_b,
               data: { "burden-selector-target": "burdenB" },
-              class: "w-full border border-gray-300 rounded-xl px-3 py-2 text-base mt-0.5",
+              class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50 mt-1",
               min: 0 %>
       </div>
     </div>
@@ -60,6 +63,6 @@
     <%= f.hidden_field :burden_b, data: { "burden-selector-target": "hiddenB" }, value: 0 %>
 
     <%= f.submit "追加",
-          class: "w-full bg-blue-500 text-white py-2.5 rounded-xl text-base font-medium" %>
+          class: "w-full bg-blue-500 text-white py-3.5 rounded-xl text-base font-semibold" %>
   </div>
 <% end %>

--- a/app/views/sheet_items/_sheet_item.html.erb
+++ b/app/views/sheet_items/_sheet_item.html.erb
@@ -17,7 +17,7 @@
                    data-inline-edit-target="input"
                    data-action="blur->inline-edit#submit keydown.enter->inline-edit#submit keydown.escape->inline-edit#cancel"
                    value="<%= sheet_item.amount %>"
-                   class="hidden w-24 border border-blue-400 rounded-lg px-2 py-0.5 text-sm text-base"
+                   class="hidden w-24 border border-blue-400 rounded-lg px-2 py-0.5 text-base"
                    min="0">
           </span>
           <% if sheet_item.card %>
@@ -28,16 +28,16 @@
 
       <div class="flex items-center gap-2 shrink-0">
         <%# 分担表示 %>
-        <span class="text-xs text-gray-500">
-          <%= @setting.member_a %>:<%= number_to_currency(sheet_item.burden_a, unit: "¥", precision: 0) %>
-          <%= @setting.member_b %>:<%= number_to_currency(sheet_item.burden_b, unit: "¥", precision: 0) %>
+        <span class="text-xs text-gray-500 leading-tight text-right">
+          <span class="block"><%= @setting.member_a %>:<%= number_to_currency(sheet_item.burden_a, unit: "¥", precision: 0) %></span>
+          <span class="block"><%= @setting.member_b %>:<%= number_to_currency(sheet_item.burden_b, unit: "¥", precision: 0) %></span>
         </span>
 
         <%# 編集ボタン %>
         <%= link_to "✎",
               edit_sheet_sheet_item_path(sheet.year_month, sheet_item),
               data: { turbo_frame: "sheet_item_#{sheet_item.id}" },
-              class: "text-blue-400 text-base leading-none w-6 h-6 flex items-center justify-center" %>
+              class: "text-blue-400 text-base leading-none w-10 h-10 flex items-center justify-center" %>
 
         <%# 削除ボタン %>
         <%= button_to "×",
@@ -49,7 +49,7 @@
                 data-action="confirm-modal#open"
                 data-confirm-modal-message-param="「<%= sheet_item.name %>」を削除しますか？"
                 data-confirm-modal-form-param="delete_sheet_item_<%= sheet_item.id %>"
-                class="text-red-400 text-lg leading-none w-6 h-6 flex items-center justify-center">
+                class="text-red-400 text-lg leading-none w-10 h-10 flex items-center justify-center">
           ×
         </button>
       </div>

--- a/app/views/sheets/index.html.erb
+++ b/app/views/sheets/index.html.erb
@@ -17,7 +17,7 @@
       <p class="text-sm mt-1">「＋ 新しい月」から作成してください</p>
     </div>
   <% else %>
-    <div class="space-y-2">
+    <div class="space-y-3">
       <% @sheets.each do |sheet| %>
         <div class="bg-white rounded-xl border border-gray-200 px-4 py-3 flex items-center justify-between">
           <div>

--- a/app/views/sheets/settlement.html.erb
+++ b/app/views/sheets/settlement.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 
   <%# 費用リスト %>
-  <div class="mt-4 space-y-2" id="sheet_items_list">
+  <div class="mt-4 space-y-3" id="sheet_items_list">
     <% @sheet_items.each do |item| %>
       <%= render "sheet_items/sheet_item", sheet_item: item, sheet: @sheet %>
     <% end %>
@@ -46,7 +46,7 @@
 
     <div class="border-t border-gray-100 mt-3 pt-3 space-y-2">
       <% [[@result.deposit_a, member_a], [@result.deposit_b, member_b]].each do |deposit, name| %>
-        <div class="flex items-center justify-between">
+        <div class="flex items-center justify-between flex-wrap gap-1">
           <span class="text-sm font-medium"><%= name %></span>
           <% if deposit > 0 %>
             <span class="text-sm text-red-600 font-bold">→ 共有口座 に <%= number_to_currency(deposit, unit: "¥", precision: 0) %></span>

--- a/app/views/template_items/_form.html.erb
+++ b/app/views/template_items/_form.html.erb
@@ -2,7 +2,7 @@
   <div>
     <label class="block text-sm font-medium text-gray-700 mb-1">費目名</label>
     <%= f.text_field :name,
-          class: "w-full border border-gray-300 rounded-xl px-4 py-2.5 text-base",
+          class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
           placeholder: "家賃" %>
     <% if template_item.errors[:name].any? %>
       <p class="text-red-500 text-sm mt-1"><%= template_item.errors[:name].first %></p>
@@ -12,7 +12,7 @@
   <div>
     <label class="block text-sm font-medium text-gray-700 mb-1">金額（円）</label>
     <%= f.number_field :amount,
-          class: "w-full border border-gray-300 rounded-xl px-4 py-2.5 text-base",
+          class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50",
           min: 0, placeholder: "120000" %>
   </div>
 
@@ -22,13 +22,13 @@
       <div class="flex-1">
         <label class="text-xs text-gray-500"><%= @setting.member_a %></label>
         <%= f.number_field :burden_a,
-              class: "w-full border border-gray-300 rounded-xl px-3 py-2 text-base mt-1",
+              class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50 mt-1",
               min: 0, placeholder: "0" %>
       </div>
       <div class="flex-1">
         <label class="text-xs text-gray-500"><%= @setting.member_b %></label>
         <%= f.number_field :burden_b,
-              class: "w-full border border-gray-300 rounded-xl px-3 py-2 text-base mt-1",
+              class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50 mt-1",
               min: 0, placeholder: "0" %>
       </div>
     </div>
@@ -39,9 +39,9 @@
     <label class="block text-sm font-medium text-gray-700 mb-1">カード（任意）</label>
     <%= f.collection_select :card_id, cards, :id, :name,
           { include_blank: "現金" },
-          class: "w-full border border-gray-300 rounded-xl px-4 py-2.5 text-base" %>
+          class: "w-full border border-gray-200 rounded-xl px-4 py-3 text-base bg-gray-50" %>
   </div>
 
   <%= f.submit template_item.new_record? ? "追加する" : "保存する",
-        class: "w-full bg-blue-500 text-white py-3 rounded-xl text-base font-medium mt-2" %>
+        class: "w-full bg-blue-500 text-white py-3.5 rounded-xl text-base font-semibold mt-2" %>
 <% end %>

--- a/app/views/template_items/_template_item.html.erb
+++ b/app/views/template_items/_template_item.html.erb
@@ -5,12 +5,14 @@
       <p class="font-medium text-sm"><%= template_item.name %></p>
       <p class="text-xs text-gray-500 mt-0.5">
         <%= number_to_currency(template_item.amount, unit: "¥", precision: 0) %>
-        ・<%= @setting.member_a %>:<%= number_to_currency(template_item.burden_a, unit: "¥", precision: 0) %>
-        / <%= @setting.member_b %>:<%= number_to_currency(template_item.burden_b, unit: "¥", precision: 0) %>
+      </p>
+      <p class="text-xs text-gray-400 leading-tight">
+        <span class="block"><%= @setting.member_a %>:<%= number_to_currency(template_item.burden_a, unit: "¥", precision: 0) %></span>
+        <span class="block"><%= @setting.member_b %>:<%= number_to_currency(template_item.burden_b, unit: "¥", precision: 0) %></span>
       </p>
     </div>
     <div class="flex gap-3">
-      <%= link_to "編集", edit_template_item_path(template_item), class: "text-blue-500 text-sm" %>
+      <%= link_to "編集", edit_template_item_path(template_item), class: "text-blue-500 text-sm py-2 px-1" %>
       <%= button_to "削除",
             template_item_path(template_item),
             method: :delete,
@@ -20,7 +22,7 @@
               data-action="confirm-modal#open"
               data-confirm-modal-message-param="「<%= template_item.name %>」を削除しますか？"
               data-confirm-modal-form-param="delete_template_item_<%= template_item.id %>"
-              class="text-red-500 text-sm">
+              class="text-red-500 text-sm py-2 px-1">
         削除
       </button>
     </div>

--- a/app/views/template_items/index.html.erb
+++ b/app/views/template_items/index.html.erb
@@ -8,7 +8,7 @@
   <% if @template_items.empty? %>
     <p class="text-center text-gray-400 py-12">テンプレートが登録されていません</p>
   <% else %>
-    <div id="template_items_list" class="space-y-2">
+    <div id="template_items_list" class="space-y-3">
       <% @template_items.each do |item| %>
         <%= render "template_item", template_item: item %>
       <% end %>

--- a/docs/adr/0009-mobile-ux-improvements.md
+++ b/docs/adr/0009-mobile-ux-improvements.md
@@ -1,0 +1,47 @@
+# ADR 0009: モバイル UX 改善（iOS Safari 対応）
+
+## ステータス
+
+採用済み（2026-03-06）
+
+## 背景
+
+iPhone Safari（特に iPhone SE / 375px 幅）で以下の問題が確認された。
+
+- SheetItem・TemplateItem の分担表示が1行に詰め込まれ、狭い画面でオーバーフローする
+- `collection_select` に `text-sm`（14px）が当たっており、iOS Safari のオートズームが発生する可能性がある（iOS Safari は 16px 未満の input/select でズームする）
+- 編集(✎)・削除(×)ボタンが `w-6 h-6`（24px）で、iOS 推奨タッチターゲット（44px）を下回る
+- 精算結果の「→ 共有口座 に ¥XXX」テキストが長く、折り返しなしで見切れる場合がある
+
+## 決定
+
+### 分担表示の縦並び化
+
+`_sheet_item.html.erb` と `_template_item.html.erb` で、メンバーごとの負担額を `<span class="block">` で縦2行に分離する。
+
+### iOS ズーム防止
+
+`_form.html.erb` / `_edit_form.html.erb` の `collection_select` から `text-sm` を削除し、グローバル CSS の `font-size: 1rem`（16px）が正しく効くようにする。あわせて `py-1.5` → `py-2.5` でタップ領域を拡大。
+
+`inline_edit` の input に重複していた `text-sm text-base` から `text-sm` を削除。
+
+### タッチターゲット拡大
+
+SheetItem の編集・削除ボタンを `w-6 h-6`（24px）→ `w-10 h-10`（40px）に拡大。
+TemplateItem の「編集」「削除」リンク・ボタンに `py-2 px-1` を追加してタップ領域を広げる。
+
+### 精算結果の折り返し
+
+`settlement.html.erb` の精算結果コンテナに `flex-wrap gap-1` を追加して、長い精算テキストが折り返せるようにする。
+
+## 理由
+
+- iOS Safari の 16px ズームルールはブラウザ仕様であり、グローバル CSS で `font-size: 1rem` を指定しても個別クラスで上書きされると無効になる
+- iOS HIG では最小タッチターゲットを 44×44pt と定義している。24px は明らかに小さく、誤タップが起きやすい
+- アプリは `max-w-md` のモバイル専用設計のため、レスポンシブ対応（sm:/md:）は不要
+
+## 影響
+
+- 変更はビュー層のみ（CSS クラスの調整）
+- モデル・サービス・ルーティングへの変更なし
+- 既存テスト 81 examples すべてグリーンを確認済み


### PR DESCRIPTION
- 分担表示を縦2行に変更（SheetItem・TemplateItem）
- select の text-sm を削除し iOS Safari のオートズームを防止
- 編集・削除ボタンを w-10 h-10（40px）に拡大
- 精算結果コンテナに flex-wrap を追加
- フォームを刷新: bg-gray-50 入力・py-3 高さ・rounded-2xl・セクションラベル
- burden_selector_controller のトグルクラスを新デザインに同期
- 全画面で space-y-3・入力スタイル・ボタン高さを統一