### PR TITLE
Fix/migration current timestamp

### DIFF
--- a/db/migrate/20260309150137_add_setting_id_to_app_tables.rb
+++ b/db/migrate/20260309150137_add_setting_id_to_app_tables.rb
@@ -15,7 +15,7 @@ class AddSettingIdToAppTables < ActiveRecord::Migration[8.0]
       # Setting が1件もない場合はデフォルト行を作成
       execute(<<~SQL)
         INSERT INTO settings (member_a, member_b, created_at, updated_at)
-        VALUES ('たろう', 'はなこ', NOW(), NOW())
+        VALUES ('たろう', 'はなこ', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
       SQL
       result = execute("SELECT id FROM settings ORDER BY id LIMIT 1")
       setting_id = result.first&.dig("id")


### PR DESCRIPTION
タイトル: fix: マイグレーションの NOW() を CURRENT_TIMESTAMP に変更
  ## 概要
  マイグレーション 20260309150137 の NOW() を CURRENT_TIMESTAMP に変更。

  ## 原因
  NOW() は PostgreSQL 専用関数。開発は schema ロード経路でこの行を実行しないため
  潜伏していたが、空のDBから全マイグレーションを流すと SQLite で
  `no such function: NOW` で失敗する。

  ## 対応
  SQLite / PostgreSQL 両対応の標準 SQL `CURRENT_TIMESTAMP` に変更。

  ## 検証
  worktree で `bin/rails db:drop db:migrate` を実行し、
  全マイグレーションが頭から完走することを確認（修正前は当該マイグレーションで停止）。