### PR TITLE
feat: /api/v1 JSON API 新設（フェーズ1 / ADR 0012）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem "stimulus-rails"
 # Use Tailwind CSS [https://github.com/rails/tailwindcss-rails]
 gem "tailwindcss-rails"
 
+# JSON シリアライザ（/api/v1 用）[https://github.com/okuramasafumi/alba]
+gem "alba"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.22"
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ gem "tailwindcss-rails"
 # JSON シリアライザ（/api/v1 用）[https://github.com/okuramasafumi/alba]
 gem "alba"
 
+# OpenAPI ドキュメント配信（手書き openapi.yaml + Swagger UI / ADR 0012 フェーズ1-8）
+gem "rswag-api"
+gem "rswag-ui"
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem "bcrypt", "~> 3.1.22"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
+    alba (3.10.0)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.22)
@@ -383,6 +384,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  alba
   bcrypt (~> 3.1.22)
   bootsnap
   brakeman

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,12 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
+    rswag-api (2.17.0)
+      activesupport (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
+    rswag-ui (2.17.0)
+      actionpack (>= 5.2, < 8.2)
+      railties (>= 5.2, < 8.2)
     rubocop (1.85.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -398,6 +404,8 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.3)
   rspec-rails
+  rswag-api
+  rswag-ui
   rubocop-rails-omakase
   shoulda-matchers
   sqlite3 (>= 2.1)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,51 @@
+module Api
+  module V1
+    # JSON API の共通基底（ADR 0012）。
+    # HTML 用 ApplicationController(ActionController::Base) とは分離し、
+    # API 向けの軽量基底 ActionController::API を使う。
+    # 認証は既存の Cookie セッション(Authentication concern)を流用するため
+    # ActionController::Cookies を include する。
+    class BaseController < ActionController::API
+      include ActionController::Cookies
+      include Authentication
+
+      before_action :require_group_membership
+
+      rescue_from ActiveRecord::RecordNotFound do
+        render_error(:not_found, "リソースが見つかりません")
+      end
+
+      private
+
+      def current_setting
+        Current.session&.user&.setting
+      end
+
+      # Authentication concern の HTML リダイレクトを上書きし、401 JSON を返す。
+      def request_authentication
+        render_error(:unauthorized, "認証が必要です")
+      end
+
+      def require_group_membership
+        return if current_setting
+
+        render_error(:forbidden, "グループに参加していません")
+      end
+
+      def render_error(status, message)
+        render json: { error: { code: status.to_s, message: message } }, status: status
+      end
+
+      # バリデーション失敗を 422 + error JSON（details にメッセージ一覧）で返す。
+      def render_validation_errors(record)
+        render json: {
+          error: {
+            code:    "unprocessable_content",
+            message: "保存に失敗しました",
+            details: record.errors.full_messages
+          }
+        }, status: :unprocessable_content
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -9,10 +9,22 @@ module Api
       include ActionController::Cookies
       include Authentication
 
+      DEFAULT_PER_PAGE = 20
+      MAX_PER_PAGE     = 100
+
       before_action :require_group_membership
 
+      # 例外ハンドリングを基底に集約し、全エラーを統一 JSON で返す（ADR 0012 / フェーズ1-5）。
       rescue_from ActiveRecord::RecordNotFound do
         render_error(:not_found, "リソースが見つかりません")
+      end
+
+      rescue_from ActionController::ParameterMissing do |e|
+        render_error(:bad_request, "必須パラメータがありません: #{e.param}")
+      end
+
+      rescue_from ActiveRecord::RecordInvalid do |e|
+        render_validation_errors(e.record)
       end
 
       private
@@ -30,6 +42,27 @@ module Api
         return if current_setting
 
         render_error(:forbidden, "グループに参加していません")
+      end
+
+      # offset / limit ページネーション（ADR 0012 / フェーズ1-6）。
+      # 戻り値: [絞り込んだリレーション, メタ情報ハッシュ]
+      def paginate(relation)
+        page     = [ params[:page].to_i, 1 ].max
+        per_page = params[:per_page].to_i
+        per_page = DEFAULT_PER_PAGE if per_page <= 0
+        per_page = [ per_page, MAX_PER_PAGE ].min
+
+        total_count = relation.count
+        total_pages = total_count.zero? ? 1 : (total_count.to_f / per_page).ceil
+        records     = relation.limit(per_page).offset((page - 1) * per_page)
+
+        meta = {
+          page:        page,
+          per_page:    per_page,
+          total_count: total_count,
+          total_pages: total_pages
+        }
+        [ records, meta ]
       end
 
       def render_error(status, message)

--- a/app/controllers/api/v1/sheet_items_controller.rb
+++ b/app/controllers/api/v1/sheet_items_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    class SheetItemsController < BaseController
+      # POST /api/v1/sheets/:sheet_year_month/sheet_items
+      def create
+        sheet = current_setting.sheets.find_by!(year_month: params[:sheet_year_month])
+        item  = sheet.sheet_items.build(sheet_item_params)
+
+        if item.save
+          render json: SheetItemSerializer.new(item).serialize, status: :created
+        else
+          render_validation_errors(item)
+        end
+      end
+
+      private
+
+      def sheet_item_params
+        params.require(:sheet_item).permit(:name, :amount, :burden_a, :burden_b, :card_id)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/sheets_controller.rb
+++ b/app/controllers/api/v1/sheets_controller.rb
@@ -3,8 +3,13 @@ module Api
     class SheetsController < BaseController
       # GET /api/v1/sheets
       def index
-        sheets = current_setting.sheets.order(year_month: :desc)
-        render json: SheetSerializer.new(sheets).serialize
+        scope        = current_setting.sheets.order(year_month: :desc)
+        sheets, meta = paginate(scope)
+
+        render json: {
+          sheets:     SheetSerializer.new(sheets).serializable_hash,
+          pagination: meta
+        }
       end
 
       # GET /api/v1/sheets/:year_month/settlement

--- a/app/controllers/api/v1/sheets_controller.rb
+++ b/app/controllers/api/v1/sheets_controller.rb
@@ -1,0 +1,22 @@
+module Api
+  module V1
+    class SheetsController < BaseController
+      # GET /api/v1/sheets
+      def index
+        sheets = current_setting.sheets.order(year_month: :desc)
+        render json: SheetSerializer.new(sheets).serialize
+      end
+
+      # GET /api/v1/sheets/:year_month/settlement
+      def settlement
+        sheet  = current_setting.sheets.find_by!(year_month: params[:year_month])
+        result = SettlementService.new(sheet).calculate
+
+        render json: {
+          sheet:      SheetSerializer.new(sheet).serializable_hash,
+          settlement: SettlementSerializer.new(result).serializable_hash
+        }
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -3,7 +3,8 @@ module Authentication
 
   included do
     before_action :require_authentication
-    helper_method :authenticated?
+    # ActionController::API には helper_method が無い（API 用 BaseController から流用するため）
+    helper_method :authenticated? if respond_to?(:helper_method)
   end
 
   class_methods do

--- a/app/models/sheet_item.rb
+++ b/app/models/sheet_item.rb
@@ -9,10 +9,19 @@ class SheetItem < ApplicationRecord
   validates :burden_b, numericality: { greater_than_or_equal_to: 0 }
   validates :template_item_id, uniqueness: { scope: :sheet_id }, allow_nil: true
   validate  :burden_sum_positive
+  validate  :card_belongs_to_same_setting
 
   private
 
   def burden_sum_positive
     errors.add(:base, "負担額の合計は 1 円以上にしてください") if burden_a.to_i + burden_b.to_i <= 0
+  end
+
+  # card は sheet と同じグループ（setting）のものでなければならない（テナント分離）。
+  def card_belongs_to_same_setting
+    return if card.nil? || sheet.nil?
+    return if card.setting_id == sheet.setting_id
+
+    errors.add(:card, "は同じグループのカードを指定してください")
   end
 end

--- a/app/serializers/api/v1/settlement_serializer.rb
+++ b/app/serializers/api/v1/settlement_serializer.rb
@@ -1,0 +1,10 @@
+module Api
+  module V1
+    # SettlementService::Result の JSON 表現（ADR 0012 / alba）。
+    class SettlementSerializer
+      include Alba::Resource
+
+      attributes :deposit_a, :deposit_b, :total_shared_amount
+    end
+  end
+end

--- a/app/serializers/api/v1/sheet_item_serializer.rb
+++ b/app/serializers/api/v1/sheet_item_serializer.rb
@@ -1,0 +1,12 @@
+module Api
+  module V1
+    # SheetItem の JSON 表現（ADR 0012 / alba）。
+    class SheetItemSerializer
+      include Alba::Resource
+
+      root_key :sheet_item, :sheet_items
+
+      attributes :id, :name, :amount, :burden_a, :burden_b, :card_id, :is_from_template
+    end
+  end
+end

--- a/app/serializers/api/v1/sheet_serializer.rb
+++ b/app/serializers/api/v1/sheet_serializer.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    # Sheet の JSON 表現（ADR 0012 / alba）。
+    class SheetSerializer
+      include Alba::Resource
+
+      root_key :sheet, :sheets
+
+      attributes :id, :year_month
+
+      attribute :label do |sheet|
+        sheet.label
+      end
+    end
+  end
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,14 @@
+Rswag::Api.configure do |c|
+
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.openapi_root = Rails.root.to_s + '/swagger'
+
+  # Inject a lambda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,14 +1,13 @@
 Rswag::Api.configure do |c|
-
   # Specify a root folder where Swagger JSON files are located
   # This is used by the Swagger middleware to serve requests for API descriptions
   # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
   # that it's configured to generate files in the same folder
-  c.openapi_root = Rails.root.to_s + '/swagger'
+  c.openapi_root = Rails.root.to_s + "/swagger"
 
   # Inject a lambda function to alter the returned Swagger prior to serialization
   # The function will have access to the rack env for the current request
   # For example, you could leverage this to dynamically assign the "host" property
   #
-  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+  # c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
 end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,0 +1,16 @@
+Rswag::Ui.configure do |c|
+
+  # List the Swagger endpoints that you want to be documented through the
+  # swagger-ui. The first parameter is the path (absolute or relative to the UI
+  # host) to the corresponding endpoint and the second is a title that will be
+  # displayed in the document selector.
+  # NOTE: If you're using rspec-api to expose Swagger files
+  # (under openapi_root) as JSON or YAML endpoints, then the list below should
+  # correspond to the relative paths for those endpoints.
+
+  c.swagger_endpoint '/api-docs/v1/openapi.yaml', 'ワリタロ API V1'
+
+  # Add Basic Auth in case your API is private
+  # c.basic_auth_enabled = true
+  # c.basic_auth_credentials 'username', 'password'
+end

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -8,7 +8,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.swagger_endpoint '/api-docs/v1/openapi.yaml', 'ワリタロ API V1'
+  c.openapi_endpoint '/api-docs/v1/openapi.yaml', 'ワリタロ API V1'
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/initializers/rswag_ui.rb
+++ b/config/initializers/rswag_ui.rb
@@ -1,5 +1,4 @@
 Rswag::Ui.configure do |c|
-
   # List the Swagger endpoints that you want to be documented through the
   # swagger-ui. The first parameter is the path (absolute or relative to the UI
   # host) to the corresponding endpoint and the second is a title that will be
@@ -8,7 +7,7 @@ Rswag::Ui.configure do |c|
   # (under openapi_root) as JSON or YAML endpoints, then the list below should
   # correspond to the relative paths for those endpoints.
 
-  c.openapi_endpoint '/api-docs/v1/openapi.yaml', 'ワリタロ API V1'
+  c.openapi_endpoint "/api-docs/v1/openapi.yaml", "ワリタロ API V1"
 
   # Add Basic Auth in case your API is private
   # c.basic_auth_enabled = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  mount Rswag::Ui::Engine => '/api-docs'
-  mount Rswag::Api::Engine => '/api-docs'
+  mount Rswag::Ui::Engine => "/api-docs"
+  mount Rswag::Api::Engine => "/api-docs"
   resource :session
   resources :passwords, param: :token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  mount Rswag::Ui::Engine => '/api-docs'
+  mount Rswag::Api::Engine => '/api-docs'
   resource :session
   resources :passwords, param: :token
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,18 @@ Rails.application.routes.draw do
 
   resources :cards, only: [ :index, :new, :create, :edit, :update, :destroy ]
 
+  # JSON API（ADR 0012）
+  namespace :api do
+    namespace :v1 do
+      resources :sheets, param: :year_month, only: [ :index ] do
+        member do
+          get :settlement
+        end
+        resources :sheet_items, only: [ :create ]
+      end
+    end
+  end
+
   # PWA関連（デフォルトのまま）
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker

--- a/docs/adr/0012-json-api-v1.md
+++ b/docs/adr/0012-json-api-v1.md
@@ -104,6 +104,41 @@ config/routes.rb                # namespace :api { namespace :v1 { ... } }
 - **テナント分離の継続**: `current_setting.sheets` のようにグループスコープで引く既存ルールを
   API でも厳守し、マルチテナントの分離（ADR 0010）を崩さない
 
+### 確定仕様（1-5 / 1-6 実装で確定）
+
+#### エラー JSON 形式（1-5）
+
+例外ハンドリングを `BaseController` に `rescue_from` で集約し、全エラーを統一形式で返す。
+
+| 状況 | ステータス | code |
+|------|-----------|------|
+| 未認証（`request_authentication` override） | 401 | `unauthorized` |
+| グループ未所属（`require_group_membership`） | 403 | `forbidden` |
+| リソース未検出（`ActiveRecord::RecordNotFound`） | 404 | `not_found` |
+| 必須パラメータ欠落（`ActionController::ParameterMissing`） | 400 | `bad_request` |
+| バリデーション失敗（`save` 失敗 / `RecordInvalid`） | 422 | `unprocessable_content` |
+
+```jsonc
+// 通常エラー
+{ "error": { "code": "not_found", "message": "リソースが見つかりません" } }
+// バリデーションエラーは details にメッセージ一覧を付与
+{ "error": { "code": "unprocessable_content", "message": "保存に失敗しました",
+             "details": ["Name can't be blank", "..."] } }
+```
+
+#### ページネーション（1-6）
+
+`BaseController#paginate(relation)` による offset/limit 方式。`?page=`・`?per_page=` で指定。
+
+- `page`: 既定 1。0 以下は 1 にフォールバック
+- `per_page`: 既定 20（`DEFAULT_PER_PAGE`）、上限 100（`MAX_PER_PAGE`）でクランプ
+- レスポンスに `pagination` メタ情報を付与
+
+```jsonc
+{ "sheets": [ /* ... */ ],
+  "pagination": { "page": 1, "per_page": 20, "total_count": 35, "total_pages": 2 } }
+```
+
 ---
 
 ## 影響・注意事項
@@ -121,4 +156,5 @@ config/routes.rb                # namespace :api { namespace :v1 { ... } }
 
 - フェーズ2でトークン認証（`Authorization: Bearer`）→ OAuth2.0 リソース/認可サーバー化を行う際、
   本 ADR の「Cookie 認証流用」を見直す ADR を別途起票する
-- エラー JSON 形式・ページネーション仕様は 1-5 / 1-6 着手時に必要なら追補する
+- エラー JSON 形式・ページネーション仕様は上記「確定仕様」に記載済み（1-5 / 1-6 実装済み）
+- 残タスク: 1-8 OpenAPI/Swagger によるドキュメント化（任意）

--- a/docs/adr/0012-json-api-v1.md
+++ b/docs/adr/0012-json-api-v1.md
@@ -1,0 +1,124 @@
+# ADR 0012: `/api/v1` JSON API の新設
+
+- **ステータス**: Accepted
+- **作成日**: 2026-06-06
+- **決定者**: ni0911
+
+---
+
+## 背景
+
+waritaro は現状 HTML（Turbo Stream）専用で、`SheetItemsController` などは
+`render turbo_stream:` でブラウザの DOM 書き換え指示を返している。これはブラウザ専用の
+インターフェースであり、プログラムから利用できる API ではない。
+
+本業の学習目標（① API 設計・実装 → ② OAuth2.0 移行 → ③ Rate Limit）を waritaro を
+練習台に積み上げるロードマップのフェーズ1として、`/api/v1` に JSON API を新設する。
+API（窓口）が無ければ認証対象もレート制限対象も存在しないため、ここが起点になる。
+
+学習ロードマップの詳細は dev-journal `topics/api-oauth-ratelimit-roadmap` を参照。
+
+---
+
+## 検討した選択肢
+
+### バージョニング方式
+
+| 方式 | 内容 | 判断 |
+|------|------|------|
+| URL パス（`/api/v1/...`） | 名前空間でバージョンを切る | **採用**。明示的で学習・運用ともに分かりやすい |
+| ヘッダ（`Accept: application/vnd.app.v1+json`） | メディアタイプでバージョン指定 | 見送り。ルーティングが不透明になり学習段階では過剰 |
+| クエリ（`?version=1`） | パラメータで指定 | 見送り。キャッシュ・ルーティングと相性が悪い |
+
+### ベースコントローラの基底クラス
+
+| 方式 | 内容 | 判断 |
+|------|------|------|
+| `ActionController::API` | API 用の軽量基底。ビュー/CSRF/Cookie を含まない | **採用**。HTML 用 `ApplicationController` と関心を分離。Cookie 認証流用のため `ActionController::Cookies` を明示的に include |
+| `ApplicationController` 継承 | 既存基底を流用 | 見送り。`allow_browser :modern`（User-Agent 必須）が API クライアントを弾く、CSRF・HTML 向けリダイレクトが混入する |
+
+### シリアライズ方式
+
+| 方式 | 判断 |
+|------|------|
+| **alba** | **採用**。軽量シリアライザ gem。クラスで `attributes` 宣言。本格的なシリアライズ層を体験でき、view 非依存で request spec とも相性が良い |
+| jbuilder | 見送り。view 層に寄るため API ロジックが分散する |
+| `as_json` 手書き | 見送り。エンドポイントが増えると整形ロジックが重複する |
+
+### 認証
+
+| 方式 | 判断 |
+|------|------|
+| **既存 Cookie 認証を流用** | **採用（フェーズ1）**。`Authentication` concern の `resume_session`（`cookies.signed[:session_id]`）をそのまま使い、`current_setting` スコープでテナント分離を維持する |
+| トークン認証（`Authorization: Bearer`） | フェーズ2（ADR 別途）で導入。ステートレス認証・OAuth2.0 はそこで扱う |
+
+---
+
+## 決定
+
+**`/api/v1` 名前空間に JSON API を新設する。** 主要な方針は以下。
+
+1. **バージョニング**: URL パス方式（`namespace :api { namespace :v1 }`）
+2. **基底クラス**: `Api::V1::BaseController < ActionController::API`
+   - `include ActionController::Cookies` で Cookie 認証を可能にする
+   - `include Authentication` で既存 `resume_session` を流用
+   - 認証失敗（`request_authentication`）は **HTML リダイレクトではなく 401 JSON** を返すよう override
+   - グループ未所属は **403 JSON** を返す（HTML 版の `new_group` リダイレクトは使わない）
+3. **シリアライズ**: alba（`app/serializers/api/v1/`）
+4. **認証/テナント分離**: 既存 Cookie 認証を流用し、全エンドポイントを `current_setting` スコープで引く
+5. **エラー JSON 形式**: `{ "error": { "code": "...", "message": "..." } }` に統一（フェーズ1-5 で例外ハンドリングを集約）
+
+### ディレクトリ／ファイル構成
+
+```
+app/
+├── controllers/api/v1/
+│   ├── base_controller.rb     # 名前空間・共通処理（認証・テナント・エラー）
+│   └── sheets_controller.rb   # GET /api/v1/sheets ほか
+└── serializers/api/v1/
+    └── sheet_serializer.rb     # alba シリアライザ
+config/routes.rb                # namespace :api { namespace :v1 { ... } }
+```
+
+### 段階的な実装（フェーズ1のスコープ）
+
+- 1-1 `Api::V1::BaseController`（名前空間・共通処理）★本 ADR の対象
+- 1-2 `GET /api/v1/sheets`（一覧 JSON）★本 ADR の対象
+- 1-3 `GET /api/v1/sheets/:year_month/settlement`（既存 SettlementService 再利用）
+- 1-4 `POST /api/v1/sheets/:ym/sheet_items`（201/422）
+- 1-5 エラー JSON 形式統一（例外ハンドリング集約）
+- 1-6 ページネーション（`?page=&per_page=`）
+- 1-7 request spec で全エンドポイント TDD
+- 1-8（余裕あれば）OpenAPI/Swagger でドキュメント化
+
+---
+
+## 理由
+
+- **関心の分離**: HTML（`ApplicationController` = `ActionController::Base`）と API（`ActionController::API`）を
+  別系統にすることで、片方の変更が他方に波及しにくい。`allow_browser :modern` や CSRF など
+  ブラウザ前提の挙動を API に持ち込まずに済む
+- **既存認証の流用**: フェーズ1ではトークン認証を導入せず、確立済みの Cookie セッションを
+  そのまま使うことで、API 設計（URL・シリアライズ・ステータスコード）の学習に集中できる。
+  ステートレス認証は依存関係的にフェーズ2で扱うのが自然
+- **テナント分離の継続**: `current_setting.sheets` のようにグループスコープで引く既存ルールを
+  API でも厳守し、マルチテナントの分離（ADR 0010）を崩さない
+
+---
+
+## 影響・注意事項
+
+- **依存追加**: `alba` gem を追加（全環境）
+- **CSRF**: `ActionController::API` は CSRF 保護を含まない。フェーズ1は Cookie 認証だが
+  GET 中心かつ学習用途のため許容。状態変更系（1-4 の POST 以降）を本格運用する場合は
+  フェーズ2のトークン認証移行とあわせて CSRF/CORS 方針を再検討する
+- **同一オリジン前提**: フェーズ1の Cookie 認証は同一オリジンからの利用を前提とする。
+  別オリジンのクライアントはフェーズ2のトークン認証で対応する
+
+---
+
+## 今後の対応
+
+- フェーズ2でトークン認証（`Authorization: Bearer`）→ OAuth2.0 リソース/認可サーバー化を行う際、
+  本 ADR の「Cookie 認証流用」を見直す ADR を別途起票する
+- エラー JSON 形式・ページネーション仕様は 1-5 / 1-6 着手時に必要なら追補する

--- a/docs/adr/0012-json-api-v1.md
+++ b/docs/adr/0012-json-api-v1.md
@@ -89,7 +89,7 @@ config/routes.rb                # namespace :api { namespace :v1 { ... } }
 - 1-5 エラー JSON 形式統一（例外ハンドリング集約）
 - 1-6 ページネーション（`?page=&per_page=`）
 - 1-7 request spec で全エンドポイント TDD
-- 1-8（余裕あれば）OpenAPI/Swagger でドキュメント化
+- 1-8 OpenAPI/Swagger でドキュメント化 → **手書き `swagger/v1/openapi.yaml` + rswag-ui** を採用（後述）
 
 ---
 
@@ -141,6 +141,24 @@ config/routes.rb                # namespace :api { namespace :v1 { ... } }
 
 ---
 
+#### API ドキュメント（1-8）
+
+OpenAPI ドキュメント化は **手書き OpenAPI スペック + rswag-ui** 方式を採用した。
+
+| 方式 | 判断 |
+|------|------|
+| **手書き `openapi.yaml` + rswag-ui** | **採用**。`swagger/v1/openapi.yaml` を手書きし、`rswag-api`/`rswag-ui` で `/api-docs` に Swagger UI を配信。既存の request spec を DSL へ書き換えずに済む |
+| rswag-specs（テスト駆動生成） | 見送り。request spec を Swagger DSL へ書き換える手間が大きい。将来エンドポイントが増えたら再検討 |
+
+- **依存追加**: `rswag-api` / `rswag-ui`（全環境）
+- スペック配置: `swagger/v1/openapi.yaml`（`rswag-api` の `openapi_root` = `swagger/`）
+- UI/スペック URL: `/api-docs`（UI） / `/api-docs/v1/openapi.yaml`（スペック）
+- `rswag-api` の配信ルートは `swagger/` 配下に限定し、`docs/`（ADR 等）を HTTP 公開しない
+- **注意**: `/api-docs` は認証なしで公開（API の形だけ／機微データは含まない）。
+  非公開にしたい場合は `rswag-ui` の `basic_auth_enabled` で保護可能
+
+---
+
 ## 影響・注意事項
 
 - **依存追加**: `alba` gem を追加（全環境）
@@ -157,4 +175,5 @@ config/routes.rb                # namespace :api { namespace :v1 { ... } }
 - フェーズ2でトークン認証（`Authorization: Bearer`）→ OAuth2.0 リソース/認可サーバー化を行う際、
   本 ADR の「Cookie 認証流用」を見直す ADR を別途起票する
 - エラー JSON 形式・ページネーション仕様は上記「確定仕様」に記載済み（1-5 / 1-6 実装済み）
-- 残タスク: 1-8 OpenAPI/Swagger によるドキュメント化（任意）
+- フェーズ1（1-1〜1-8）は完了。エンドポイント追加時は `swagger/v1/openapi.yaml` を追従更新する
+- フェーズ2でトークン認証を入れる際、OpenAPI に `securitySchemes`（Bearer）を追記する

--- a/spec/models/sheet_item_spec.rb
+++ b/spec/models/sheet_item_spec.rb
@@ -17,6 +17,29 @@ RSpec.describe SheetItem, type: :model do
       item = build(:sheet_item, burden_a: 1000, burden_b: 0)
       expect(item).to be_valid
     end
+
+    describe 'card のテナント整合性' do
+      let(:setting) { create(:setting) }
+      let(:sheet)   { create(:sheet, setting: setting) }
+
+      it '同じグループの card なら有効' do
+        card = create(:card, setting: setting)
+        item = build(:sheet_item, sheet: sheet, card: card)
+        expect(item).to be_valid
+      end
+
+      it '別グループの card は無効' do
+        other_card = create(:card, setting: create(:setting))
+        item = build(:sheet_item, sheet: sheet, card: other_card)
+        expect(item).not_to be_valid
+        expect(item.errors[:card]).to be_present
+      end
+
+      it 'card 未指定なら有効' do
+        item = build(:sheet_item, sheet: sheet, card: nil)
+        expect(item).to be_valid
+      end
+    end
   end
 
   describe 'アソシエーション' do

--- a/spec/requests/api/v1/sheet_items_spec.rb
+++ b/spec/requests/api/v1/sheet_items_spec.rb
@@ -45,6 +45,12 @@ RSpec.describe "Api::V1::SheetItems", type: :request do
         expect(response.parsed_body.dig("error", "details")).to be_present
       end
 
+      it "必須パラメータ(sheet_item)が無いと 400 と error JSON を返す" do
+        post "/api/v1/sheets/#{sheet.year_month}/sheet_items", params: {}
+        expect(response).to have_http_status(:bad_request)
+        expect(response.parsed_body.dig("error", "code")).to eq("bad_request")
+      end
+
       it "存在しない年月は 404 を返す" do
         post "/api/v1/sheets/2099-12/sheet_items", params: valid_params
         expect(response).to have_http_status(:not_found)

--- a/spec/requests/api/v1/sheet_items_spec.rb
+++ b/spec/requests/api/v1/sheet_items_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::SheetItems", type: :request do
+  let(:setting) { create(:setting) }
+  let(:user)    { create(:user, setting: setting) }
+  let(:sheet)   { create(:sheet, year_month: "2026-03", setting: setting) }
+
+  describe "POST /api/v1/sheets/:year_month/sheet_items" do
+    let(:valid_params) do
+      { sheet_item: { name: "電気代", amount: 8000, burden_a: 4000, burden_b: 4000 } }
+    end
+
+    context "未認証" do
+      it "401 と error JSON を返す" do
+        post "/api/v1/sheets/#{sheet.year_month}/sheet_items", params: valid_params
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body.dig("error", "code")).to eq("unauthorized")
+      end
+    end
+
+    context "認証あり" do
+      before { sign_in(user) }
+
+      it "201 と作成された費用 JSON を返す" do
+        expect {
+          post "/api/v1/sheets/#{sheet.year_month}/sheet_items", params: valid_params
+        }.to change(sheet.sheet_items, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        item = response.parsed_body.fetch("sheet_item")
+        expect(item).to include("id", "name", "amount", "burden_a", "burden_b")
+        expect(item["name"]).to eq("電気代")
+        expect(item["amount"]).to eq(8000)
+      end
+
+      it "不正なパラメータは 422 とバリデーションエラーを返す" do
+        invalid = { sheet_item: { name: "", amount: 8000, burden_a: 0, burden_b: 0 } }
+
+        expect {
+          post "/api/v1/sheets/#{sheet.year_month}/sheet_items", params: invalid
+        }.not_to change(SheetItem, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body.dig("error", "code")).to eq("unprocessable_content")
+        expect(response.parsed_body.dig("error", "details")).to be_present
+      end
+
+      it "存在しない年月は 404 を返す" do
+        post "/api/v1/sheets/2099-12/sheet_items", params: valid_params
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "他グループのシートには追加できない（テナント分離・404）" do
+        other_setting = create(:setting)
+        other_sheet   = create(:sheet, year_month: "2026-07", setting: other_setting)
+
+        expect {
+          post "/api/v1/sheets/#{other_sheet.year_month}/sheet_items", params: valid_params
+        }.not_to change(SheetItem, :count)
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/sheet_items_spec.rb
+++ b/spec/requests/api/v1/sheet_items_spec.rb
@@ -33,6 +33,28 @@ RSpec.describe "Api::V1::SheetItems", type: :request do
         expect(item["amount"]).to eq(8000)
       end
 
+      it "自グループの card_id なら紐付けて 201 を返す" do
+        card = create(:card, setting: setting)
+
+        post "/api/v1/sheets/#{sheet.year_month}/sheet_items",
+             params: { sheet_item: valid_params[:sheet_item].merge(card_id: card.id) }
+
+        expect(response).to have_http_status(:created)
+        expect(response.parsed_body.dig("sheet_item", "card_id")).to eq(card.id)
+      end
+
+      it "他グループの card_id は紐付けられず 422（テナント分離）" do
+        other_card = create(:card, setting: create(:setting))
+
+        expect {
+          post "/api/v1/sheets/#{sheet.year_month}/sheet_items",
+               params: { sheet_item: valid_params[:sheet_item].merge(card_id: other_card.id) }
+        }.not_to change(SheetItem, :count)
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.parsed_body.dig("error", "code")).to eq("unprocessable_content")
+      end
+
       it "不正なパラメータは 422 とバリデーションエラーを返す" do
         invalid = { sheet_item: { name: "", amount: 8000, burden_a: 0, burden_b: 0 } }
 

--- a/spec/requests/api/v1/sheets_spec.rb
+++ b/spec/requests/api/v1/sheets_spec.rb
@@ -44,6 +44,44 @@ RSpec.describe "Api::V1::Sheets", type: :request do
         year_months = response.parsed_body.fetch("sheets").map { |s| s["year_month"] }
         expect(year_months).to contain_exactly("2026-02")
       end
+
+      it "pagination メタ情報を返す（デフォルト page=1 per_page=20）" do
+        create(:sheet, year_month: "2026-01", setting: setting)
+
+        get "/api/v1/sheets"
+
+        meta = response.parsed_body.fetch("pagination")
+        expect(meta).to include(
+          "page"        => 1,
+          "per_page"    => 20,
+          "total_count" => 1,
+          "total_pages" => 1
+        )
+      end
+
+      it "page / per_page で絞り込める" do
+        %w[2026-01 2026-02 2026-03].each { |ym| create(:sheet, year_month: ym, setting: setting) }
+
+        get "/api/v1/sheets", params: { per_page: 2, page: 1 }
+        page1 = response.parsed_body
+        expect(page1.fetch("sheets").map { |s| s["year_month"] }).to eq(%w[2026-03 2026-02])
+        expect(page1.dig("pagination", "total_count")).to eq(3)
+        expect(page1.dig("pagination", "total_pages")).to eq(2)
+
+        get "/api/v1/sheets", params: { per_page: 2, page: 2 }
+        page2 = response.parsed_body
+        expect(page2.fetch("sheets").map { |s| s["year_month"] }).to eq(%w[2026-01])
+      end
+
+      it "per_page は上限(100)でクランプされる" do
+        get "/api/v1/sheets", params: { per_page: 9999 }
+        expect(response.parsed_body.dig("pagination", "per_page")).to eq(100)
+      end
+
+      it "不正な page は 1 にフォールバックする" do
+        get "/api/v1/sheets", params: { page: 0 }
+        expect(response.parsed_body.dig("pagination", "page")).to eq(1)
+      end
     end
 
     context "グループ未所属のユーザー" do

--- a/spec/requests/api/v1/sheets_spec.rb
+++ b/spec/requests/api/v1/sheets_spec.rb
@@ -1,0 +1,117 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Sheets", type: :request do
+  let(:setting) { create(:setting) }
+  let(:user)    { create(:user, setting: setting) }
+
+  describe "GET /api/v1/sheets" do
+    context "未認証" do
+      it "401 と error JSON を返す" do
+        get "/api/v1/sheets"
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body.dig("error", "code")).to eq("unauthorized")
+      end
+    end
+
+    context "認証あり" do
+      before { sign_in(user) }
+
+      it "200 と JSON を返す" do
+        get "/api/v1/sheets"
+        expect(response).to have_http_status(:ok)
+        expect(response.media_type).to eq("application/json")
+      end
+
+      it "自グループのシートを新しい順に返す" do
+        create(:sheet, year_month: "2026-01", setting: setting)
+        create(:sheet, year_month: "2026-03", setting: setting)
+
+        get "/api/v1/sheets"
+
+        sheets = response.parsed_body.fetch("sheets")
+        expect(sheets.map { |s| s["year_month"] }).to eq(%w[2026-03 2026-01])
+        expect(sheets.first).to include("id", "year_month", "label")
+        expect(sheets.first["label"]).to eq("2026年3月")
+      end
+
+      it "他グループのシートは含めない（テナント分離）" do
+        other_setting = create(:setting)
+        create(:sheet, year_month: "2026-05", setting: other_setting)
+        create(:sheet, year_month: "2026-02", setting: setting)
+
+        get "/api/v1/sheets"
+
+        year_months = response.parsed_body.fetch("sheets").map { |s| s["year_month"] }
+        expect(year_months).to contain_exactly("2026-02")
+      end
+    end
+
+    context "グループ未所属のユーザー" do
+      let(:no_group_user) { create(:user, setting: nil) }
+      before { sign_in(no_group_user) }
+
+      it "403 と error JSON を返す" do
+        get "/api/v1/sheets"
+        expect(response).to have_http_status(:forbidden)
+        expect(response.parsed_body.dig("error", "code")).to eq("forbidden")
+      end
+    end
+  end
+
+  describe "GET /api/v1/sheets/:year_month/settlement" do
+    let(:sheet) { create(:sheet, year_month: "2026-03", setting: setting) }
+
+    context "未認証" do
+      it "401 と error JSON を返す" do
+        get "/api/v1/sheets/#{sheet.year_month}/settlement"
+        expect(response).to have_http_status(:unauthorized)
+        expect(response.parsed_body.dig("error", "code")).to eq("unauthorized")
+      end
+    end
+
+    context "認証あり" do
+      before { sign_in(user) }
+
+      it "200 とシート情報・精算結果を返す" do
+        create(:sheet_item, sheet: sheet, amount: 5000, burden_a: 3000, burden_b: 2000)
+        create(:sheet_item, sheet: sheet, amount: 4000, burden_a: 1000, burden_b: 3000)
+
+        get "/api/v1/sheets/#{sheet.year_month}/settlement"
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+        expect(body.dig("sheet", "year_month")).to eq("2026-03")
+        expect(body.dig("sheet", "label")).to eq("2026年3月")
+        expect(body.dig("settlement", "deposit_a")).to eq(4000)
+        expect(body.dig("settlement", "deposit_b")).to eq(5000)
+        expect(body.dig("settlement", "total_shared_amount")).to eq(9000)
+      end
+
+      it "片方のみ負担（私物寄り）の費用も負担額どおり集計する" do
+        create(:sheet_item, sheet: sheet, amount: 3000, burden_a: 3000, burden_b: 0)
+
+        get "/api/v1/sheets/#{sheet.year_month}/settlement"
+
+        body = response.parsed_body
+        expect(body.dig("settlement", "deposit_a")).to eq(3000)
+        expect(body.dig("settlement", "deposit_b")).to eq(0)
+        expect(body.dig("settlement", "total_shared_amount")).to eq(3000)
+      end
+
+      it "存在しない年月は 404 と error JSON を返す" do
+        get "/api/v1/sheets/2099-12/settlement"
+        expect(response).to have_http_status(:not_found)
+        expect(response.parsed_body.dig("error", "code")).to eq("not_found")
+      end
+
+      it "他グループのシートは 404（テナント分離）" do
+        other_setting = create(:setting)
+        other_sheet   = create(:sheet, year_month: "2026-07", setting: other_setting)
+
+        get "/api/v1/sheets/#{other_sheet.year_month}/settlement"
+
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end

--- a/spec/requests/api_docs_spec.rb
+++ b/spec/requests/api_docs_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe "API ドキュメント (rswag)", type: :request do
+  it "OpenAPI スペック(YAML)を認証なしで配信する" do
+    get "/api-docs/v1/openapi.yaml"
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("ワリタロ会計部 API")
+  end
+
+  it "Swagger UI を配信する" do
+    get "/api-docs/index.html"
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/swagger/v1/openapi.yaml
+++ b/swagger/v1/openapi.yaml
@@ -1,0 +1,342 @@
+openapi: 3.0.3
+info:
+  title: ワリタロ会計部 API
+  version: "1.0.0"
+  description: |
+    ワリタロ会計部の JSON API（フェーズ1 / ADR 0012）。
+
+    - 認証は既存の Cookie セッション（`session_id`、署名付き・SameSite=Lax）を流用する。
+      フェーズ1は同一オリジンからの利用を前提とする。
+    - 全エンドポイントは認証ユーザーが所属するグループ（Setting）のデータのみを返す（テナント分離）。
+    - エラーは `{ "error": { "code": ..., "message": ... } }` 形式に統一。
+      バリデーション失敗（422）は `details` にメッセージ一覧を含む。
+
+servers:
+  - url: /
+    description: 同一オリジン
+
+tags:
+  - name: Sheets
+    description: 月次シート
+  - name: SheetItems
+    description: シート費用項目
+
+paths:
+  /api/v1/sheets:
+    get:
+      tags: [Sheets]
+      summary: シート一覧
+      description: 認証ユーザーのグループのシートを新しい順（year_month 降順）で返す。ページネーション対応。
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PerPage'
+      responses:
+        '200':
+          description: シート一覧
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SheetsResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+
+  /api/v1/sheets/{year_month}/settlement:
+    get:
+      tags: [Sheets]
+      summary: 精算結果
+      description: 指定シートの精算結果（各人の負担合計と共有費用合計）を返す。
+      parameters:
+        - $ref: '#/components/parameters/YearMonth'
+      responses:
+        '200':
+          description: 精算結果
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SettlementResponse'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/sheets/{year_month}/sheet_items:
+    post:
+      tags: [SheetItems]
+      summary: 費用項目の追加
+      description: |
+        指定シートに費用項目を追加する。
+        `card_id` を指定する場合、同じグループのカードである必要がある（異なるグループのカードは 422）。
+      parameters:
+        - $ref: '#/components/parameters/YearMonth'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SheetItemCreateRequest'
+      responses:
+        '201':
+          description: 作成された費用項目
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SheetItemResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableContent'
+
+components:
+  parameters:
+    YearMonth:
+      name: year_month
+      in: path
+      required: true
+      description: 対象シートの年月（YYYY-MM）
+      schema:
+        type: string
+        pattern: '^\d{4}-(0[1-9]|1[0-2])$'
+        example: "2026-03"
+    Page:
+      name: page
+      in: query
+      required: false
+      description: ページ番号（既定 1、1 未満は 1 に補正）
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    PerPage:
+      name: per_page
+      in: query
+      required: false
+      description: 1ページあたりの件数（既定 20、上限 100）
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+
+  schemas:
+    Sheet:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 1
+        year_month:
+          type: string
+          example: "2026-03"
+        label:
+          type: string
+          example: "2026年3月"
+      required: [id, year_month, label]
+
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: integer
+          example: 1
+        per_page:
+          type: integer
+          example: 20
+        total_count:
+          type: integer
+          example: 35
+        total_pages:
+          type: integer
+          example: 2
+      required: [page, per_page, total_count, total_pages]
+
+    SheetsResponse:
+      type: object
+      properties:
+        sheets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Sheet'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+      required: [sheets, pagination]
+
+    Settlement:
+      type: object
+      properties:
+        deposit_a:
+          type: integer
+          description: A の負担合計
+          example: 4000
+        deposit_b:
+          type: integer
+          description: B の負担合計
+          example: 5000
+        total_shared_amount:
+          type: integer
+          description: 共有費用の合計（deposit_a + deposit_b）
+          example: 9000
+      required: [deposit_a, deposit_b, total_shared_amount]
+
+    SettlementResponse:
+      type: object
+      properties:
+        sheet:
+          $ref: '#/components/schemas/Sheet'
+        settlement:
+          $ref: '#/components/schemas/Settlement'
+      required: [sheet, settlement]
+
+    SheetItem:
+      type: object
+      properties:
+        id:
+          type: integer
+          example: 10
+        name:
+          type: string
+          example: "電気代"
+        amount:
+          type: integer
+          example: 8000
+        burden_a:
+          type: integer
+          example: 4000
+        burden_b:
+          type: integer
+          example: 4000
+        card_id:
+          type: integer
+          nullable: true
+          example: null
+        is_from_template:
+          type: boolean
+          example: false
+      required: [id, name, amount, burden_a, burden_b, is_from_template]
+
+    SheetItemCreateRequest:
+      type: object
+      properties:
+        sheet_item:
+          type: object
+          properties:
+            name:
+              type: string
+              example: "電気代"
+            amount:
+              type: integer
+              minimum: 0
+              example: 8000
+            burden_a:
+              type: integer
+              minimum: 0
+              example: 4000
+            burden_b:
+              type: integer
+              minimum: 0
+              example: 4000
+            card_id:
+              type: integer
+              nullable: true
+              description: 紐付けるカード（同一グループのカードのみ可）
+          required: [name, amount, burden_a, burden_b]
+      required: [sheet_item]
+
+    SheetItemResponse:
+      type: object
+      properties:
+        sheet_item:
+          $ref: '#/components/schemas/SheetItem'
+      required: [sheet_item]
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              example: "not_found"
+            message:
+              type: string
+              example: "リソースが見つかりません"
+          required: [code, message]
+      required: [error]
+
+    ValidationError:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              example: "unprocessable_content"
+            message:
+              type: string
+              example: "保存に失敗しました"
+            details:
+              type: array
+              items:
+                type: string
+              example: ["Name can't be blank"]
+          required: [code, message, details]
+      required: [error]
+
+  responses:
+    BadRequest:
+      description: 必須パラメータの欠落
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error:
+              code: "bad_request"
+              message: "必須パラメータがありません: sheet_item"
+    Unauthorized:
+      description: 未認証
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error:
+              code: "unauthorized"
+              message: "認証が必要です"
+    Forbidden:
+      description: グループ未所属
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error:
+              code: "forbidden"
+              message: "グループに参加していません"
+    NotFound:
+      description: リソースが見つからない（他グループのシート含む）
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            error:
+              code: "not_found"
+              message: "リソースが見つかりません"
+    UnprocessableContent:
+      description: バリデーション失敗
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationError'


### PR DESCRIPTION
## 概要

学習ロードマップ フェーズ1として `/api/v1` JSON API を新設しました（ADR 0012）。HTML(Turbo Stream)専用だった waritaro に、プログラムから利用できる JSON API の窓口を追加します。

## エンドポイント

| メソッド | パス | 内容 |
|---|---|---|
| GET | `/api/v1/sheets` | シート一覧（新しい順・ページネーション対応） |
| GET | `/api/v1/sheets/:year_month/settlement` | 精算結果（SettlementService 再利用） |
| POST | `/api/v1/sheets/:year_month/sheet_items` | 費用項目の追加（201/422） |

## 設計のポイント

- **基底クラス**: `Api::V1::BaseController < ActionController::API`（HTML 用 ApplicationController と関心分離）
- **認証**: 既存 Cookie セッションを流用（`request_authentication` を override し 401 JSON）。グループ未所属は 403
- **テナント分離**: 全クエリを `current_setting.sheets` スコープで実行
- **シリアライズ**: alba（`app/serializers/api/v1/`）
- **エラー JSON 統一**: `rescue_from` で集約（ParameterMissing→400 / RecordNotFound→404 / RecordInvalid→422）。形式は `{ error: { code, message[, details] } }`
- **ページネーション**: `?page=&per_page=`（既定20・上限100）+ `pagination` メタ
- **OpenAPI ドキュメント**: 手書き `swagger/v1/openapi.yaml` を rswag-ui で `/api-docs` 配信

## セキュリティ対応

- `card_id` のクロステナント参照（IDOR）を `SheetItem` のモデルバリデーション `card_belongs_to_same_setting` で封鎖（API・HTML 両経路）

## テスト

- 全テスト **128 examples / 0 failures**（request spec で全エンドポイント TDD）

## 補足

- フェーズ2（トークン認証 → OAuth2.0）で Cookie 認証流用・CSRF/CORS 方針を見直す予定（ADR 0012 記載）
- `/api-docs` は現状認証なし公開（API の形のみ・機微データなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)